### PR TITLE
Added logic to make group display more compact for iPad screens

### DIFF
--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -344,9 +344,11 @@ class Group extends Component {
             </div>
         }
 
+        let groupStyle = this.props.renderFixtures ? classes.Group : classes.NarrowGroup;
+        let groupTableStyle = this.props.renderFixtures ? classes.GroupTable : classes.NarrowGroupTable;
         return (
-            <div className = {classes.Group}>
-                <div className = {classes.GroupTable}>
+            <div className = {groupStyle}>
+                <div className = {groupTableStyle}>
                     <p className = {classes.GroupName}>{this.props.group.name}</p>
                     {groupDisplay}
                 </div>

--- a/src/components/Group.module.css
+++ b/src/components/Group.module.css
@@ -7,9 +7,28 @@
     display: flex;
 }
 
+.NarrowGroup {
+    overflow: hidden;
+    margin: 8px auto;
+    width: 450px;
+    text-align: left;
+    font-size: 1.1rem;
+    display: flex;
+}
+
 .GroupTable {
     margin: 4px;
     width: 50%;
+    padding: 4px 8px;
+    border: 1px solid #eee;
+    box-shadow: 0 2px 3px #ccc;
+    float: left;
+    background-color: white;
+}
+
+.NarrowGroupTable {
+    margin: 4px;
+    width: 100%;
     padding: 4px 8px;
     border: 1px solid #eee;
     box-shadow: 0 2px 3px #ccc;

--- a/src/containers/CupTable.js
+++ b/src/containers/CupTable.js
@@ -7,6 +7,7 @@ import PnpScoring from '../components/PnPScoring';
 import Footer from '../components/Footer';
 import SimpleStorage, { clearStorage } from 'react-simple-storage';
 import {mens2018Default, womens2019Default, womens2015Default, mens2002Default, mens1966Default, genaric32Default, genaric24Default, genaric16Default } from './defaults';
+import classes from './CupTable.module.css';
 
 class CupTable extends Component {
     constructor(props) {
@@ -823,6 +824,13 @@ class CupTable extends Component {
        }
     }
 
+    toggleFixtures = (event) => {
+        //event.target.innerHTML = ( event.target.innerHTML == "Enter Scores" ? "Hide Scores" : "Enter Scores" );
+        let stateCopy = this.deepCopy(this.state);
+        stateCopy.renderFixtures = !this.state.renderFixtures;
+        this.setState(stateCopy);
+    }
+
     tieArrowHandler = (event, [group, teamIndex, upArrow]) => {
         const groupIndex = this.state.groups.findIndex(subGroup => {
             return subGroup.name === group.name;
@@ -1100,7 +1108,7 @@ class CupTable extends Component {
                 teamsDB={this.state.teams}
                 changed={this.scoreChangedHandler}
                 arrowClicked={this.tieArrowHandler}
-                renderFixtures="true"
+                renderFixtures={this.state.renderFixtures}
                 teamClicked = {this.teamClickHandler}
                 editing = {editing}
                 editingTeamIndex = {editingTeamIndex}
@@ -1123,6 +1131,8 @@ class CupTable extends Component {
                     thirdGroup="true"
                 />        
             }
+            
+            let groupStandingsClass = this.state.renderFixtures ? classes.GroupStandingsAndScores : classes.GroupStandings;
 
         return (
             <Aux>
@@ -1150,7 +1160,10 @@ class CupTable extends Component {
                 }
                 <h1>{this.state.title}</h1>
                 <h2>Group Stage</h2>
-                {groups}   
+                <button onClick={(event) => this.toggleFixtures(event)}>Toggle Score Input</button> 
+                <div className={groupStandingsClass}>
+                    {groups} 
+                </div>
                 {thirdPlaceGroup}
                 {  Object.keys(this.state.knockout).length > 0 
                     ? <KnockoutStage 

--- a/src/containers/CupTable.module.css
+++ b/src/containers/CupTable.module.css
@@ -1,0 +1,11 @@
+.GroupStandings {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-gap: 10px;
+}
+
+.GroupStandingsAndScores {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-gap: 10px;
+}

--- a/src/containers/defaults.js
+++ b/src/containers/defaults.js
@@ -687,7 +687,8 @@ export let mens2018Default = {
             ]
         }
     ],
-    knockout: {}
+    knockout: {},
+    renderFixtures: "true"
 }
 
 export let womens2019Default = {
@@ -1208,7 +1209,8 @@ export let womens2019Default = {
             ]
         }
     ],
-    knockout: {}
+    knockout: {},
+    renderFixtures: "true"
 }
 
 export let womens2015Default = {
@@ -1729,7 +1731,8 @@ export let womens2015Default = {
             ]
         }
     ],
-    knockout: {}
+    knockout: {},
+    renderFixtures: "true"
 }
 
 export let mens2002Default = {
@@ -2420,7 +2423,8 @@ export let mens2002Default = {
             ]
         }
     ],
-    knockout: {}
+    knockout: {},
+    renderFixtures: "true"
 }
 
 export let mens1966Default = {
@@ -2771,7 +2775,8 @@ export let mens1966Default = {
             ]
         },            
     ],
-    knockout: {}
+    knockout: {},
+    renderFixtures: "true"
 }
 
 export let genaric32Default = {
@@ -3462,7 +3467,8 @@ export let genaric32Default = {
             ]
         }
     ],
-    knockout: {}
+    knockout: {},
+    renderFixtures: "true"
 }
 
 export let genaric24Default = {
@@ -3983,7 +3989,8 @@ export let genaric24Default = {
             ]
         }
     ],
-    knockout: {}
+    knockout: {},
+    renderFixtures: "true"
 }
 
 export let genaric16Default = {
@@ -4334,5 +4341,6 @@ export let genaric16Default = {
             ]
         },            
     ],
-    knockout: {}
+    knockout: {},
+    renderFixtures: "true"
 }


### PR DESCRIPTION
This change adds a button to the main screen that allows you to toggle the score input fields off and on. I found that without the score input fields we were better able to see the full results as we played the game. This let people figure out which games to focus on over others. Then we toggle scores on at the end of the match day. Let me know if you have any questions.